### PR TITLE
#6 - Fix error messages for undocumented errors

### DIFF
--- a/src/service/DatasetEditManager.ts
+++ b/src/service/DatasetEditManager.ts
@@ -45,7 +45,7 @@ export class DatasetEditManager {
     }
     private editedMemList = {};
 
-    constructor(private rest: ZoweRestClient) {}
+    constructor(private rest: ZoweRestClient) { }
 
     public register(subscriptions: vscode.Disposable[], dataProvider: MVSDataProvider) {
         subscriptions.push(
@@ -90,8 +90,11 @@ export class DatasetEditManager {
                 this.unmarkEditedMember(DatasetEditManager.processFilePath(filePath));
                 return true;
             } catch (error) {
-                const errorText: string = error.error ? error.error : error;
-                await vscode.window.showErrorMessage(errorText);
+                let errorText: string = error.error ? error.error : error;
+                if (error && error.message === "fwrite() error") {
+                    errorText = "Dataset size exceeded. INTERNAL_SERVER_ERROR_500";
+                }
+                await vscode.window.showErrorMessage(errorText + "!");
             }
         }
         return false;

--- a/src/ui/tree/DatasetDataProvider.ts
+++ b/src/ui/tree/DatasetDataProvider.ts
@@ -252,7 +252,12 @@ export class MVSDataProvider implements vscode.TreeDataProvider<ZNode> {
             }
             return result;
         } catch (error) {
-            return this.processZoweError(error, host);
+            let message = error.body;
+            if (error.message && error.message ===
+                "ServletDispatcher failed - received TSO Prompt when expecting TsoServletResponse") {
+                message = "Your dataset may contain archived dataset. INTERNAL_SERVER_ERROR_500";
+            }
+            return this.processZoweError(message, host);
         }
     }
 


### PR DESCRIPTION
ZOWE API does not support some error classes yet, this is an workaround in order to have a more accurate experience using zos/Explorer